### PR TITLE
Github - Allow hyphens in organisation and repository name

### DIFF
--- a/Tests/Web/Features/Result/GitHub/GitHubScannerTests.cs
+++ b/Tests/Web/Features/Result/GitHub/GitHubScannerTests.cs
@@ -45,6 +45,15 @@ namespace ICanHasDotnetCore.Tests.Web.Features.Result.GitHub
             result.ErrorString.Should().Be("OctopusDeploy/DoesNotExist does not exist or is not publically accessible");
         }
 
+        [Fact]
+        public async Task RepoHasHyphens()
+        {
+            var result = await CreateScanner().Scan("OctopusDeploy/Octopus-Samples");
+            result.WasSuccessful.Should().BeTrue(result.ErrorString);
+            var names = result.Value.Select(p => p.Name).ToArray();
+            names.ShouldAllBeEquivalentTo(new[] { "packages.config" });
+        }
+
         private GitHubScanner CreateScanner()
         {
             return new GitHubScanner(

--- a/Web/Features/result/GitHub/GitHubScanner.cs
+++ b/Web/Features/result/GitHub/GitHubScanner.cs
@@ -27,7 +27,7 @@ namespace ICanHasDotnetCore.Web.Features.Result.GitHub
         {
             try
             {
-                var match = Regex.Match(repoId, @"^\W*(\w+)/(\w+)\W*$");
+                var match = Regex.Match(repoId, @"^\W*([\w-]+)/([\w-]+)\W*$");
                 if (!match.Success)
                     return Result<PackagesFileData[]>.Failed($"{repoId} is not recognised as a GitHub repository name");
 


### PR DESCRIPTION
This is to enable repositories with names such as rebus-org/rebus and rabbitmq/rabbitmq-dotnet-client