### PR TITLE
Replace package.config with packages.config

### DIFF
--- a/Magic/Magic.nuspec
+++ b/Magic/Magic.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</licenseUrl>
     <projectUrl>https://github.com/OctopusDeploy/ICanHasDotnetCore</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Scans package.config files and determines whether the nuget packages target .NETStandard</description>
+    <description>Scans packages.config files and determines whether the nuget packages target .NETStandard</description>
     <copyright>Copyright 2016</copyright>
   </metadata>
 </package>

--- a/Web/Features/home/home.html
+++ b/Web/Features/home/home.html
@@ -5,7 +5,7 @@
             <md-tabs md-dynamic-height md-selected="vm.selectedTab">
                 <md-tab label="Upload Package Files">
                     <p>
-                        Upload your project's <code>package.config</code> files for analysis and we will build a visualisation of the packages and whether
+                        Upload your project's <code>packages.config</code> files for analysis and we will build a visualisation of the packages and whether
                         .NET Standard versions are available on nuget.org
                     </p>
 
@@ -16,7 +16,7 @@
                             </md-input-container>
                             <div>
                                 <input class="ng-hide" id="input-file-id-{{$index}}" multiple type="file" ng-file-model="item.file" accept=".config" />
-                                <label for="input-file-id-{{$index}}" class="choose-file md-button md-raised" ng-hide="item.file">Choose package.config File</label>
+                                <label for="input-file-id-{{$index}}" class="choose-file md-button md-raised" ng-hide="item.file">Choose packages.config File</label>
                                 <div>
                                     <span class="package-file-name">{{ item.file.name}}</span>
                                     <md-button class="md-danger md-icon-button" title="Delete" ng-show="item.file" ng-click="vm.deletePackageFile(item)">
@@ -71,7 +71,7 @@
                         <external-link href="http://www.michael-whelan.net/porting-dotnet-framework-library-to-dotnet-core/">guide</external-link> showing how to analyse an existing project and port it.
                     </li>
                     <li>
-                        Have your other dependencies been ported to .NET Standard. To do that, either upload your project's <code>package.config</code> files above
+                        Have your other dependencies been ported to .NET Standard. To do that, either upload your project's <code>packages.config</code> files above
                         or download the <a href="" ui-sref="layout.console">command line tool</a>.
                     </li>
 


### PR DESCRIPTION
There are 4 occurrences of `package.config`, which doesn't actually exist in the NuGet ecosystem. This PR changes those references over to `packages.config`.