### PR TITLE
Removed duplicate "http://" in links to GraphViz

### DIFF
--- a/Web/Features/Console/Console.html
+++ b/Web/Features/Console/Console.html
@@ -30,9 +30,9 @@
         <ul>
             <li><code>Flat.txt</code> - A flat list of the dependencies</li>
             <li><code>Tree.txt</code> - A tree of the dependencies</li>
-            <li><code>All.gv</code> - A <external-link href="http://http://www.graphviz.org/">GraphVis</external-link> file of all dependencies of all projects</li>
-            <li><code>1Level.gv</code> - A <external-link href="http://http://www.graphviz.org/">GraphVis</external-link> file of direct dependencies of all projects</li>
-            <li><code>&lt;Project&gt;.gv</code> - A <external-link href="http://http://www.graphviz.org/">GraphVis</external-link> file of dependencies for <code>&lt;Project&gt;</code></li>
+            <li><code>All.gv</code> - A <external-link href="http://www.graphviz.org/">GraphVis</external-link> file of all dependencies of all projects</li>
+            <li><code>1Level.gv</code> - A <external-link href="http://www.graphviz.org/">GraphVis</external-link> file of direct dependencies of all projects</li>
+            <li><code>&lt;Project&gt;.gv</code> - A <external-link href="http://www.graphviz.org/">GraphVis</external-link> file of dependencies for <code>&lt;Project&gt;</code></li>
         </ul>
     </p>
 
@@ -77,7 +77,7 @@
     </div>
     <h3 class="md-subtitle">GraphVis</h3>
     <p>
-        The <code>.gv</code> file is a GraphVis dot file. It can be used with the <external-link href="http://http://www.graphviz.org/">GraphVis</external-link> application, online at <external-link href="http://www.webgraphviz.com/">WebGraphViz</external-link>
+        The <code>.gv</code> file is a GraphVis dot file. It can be used with the <external-link href="http://www.graphviz.org/">GraphVis</external-link> application, online at <external-link href="http://www.webgraphviz.com/">WebGraphViz</external-link>
         or with many other web and non-web based network graphing applications.
     </p>
 </div>


### PR DESCRIPTION
The links to GraphViz on the Console page were not working.  I think this should resolve that.